### PR TITLE
fix(docker): preserve Windows base-image PATH in container image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin/
 publish/
 /.claude
 /nul
+/docs/superpowers

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,10 @@ RUN Invoke-WebRequest -Uri "https://go.microsoft.com/fwlink/?linkid=2237387" `
         -ArgumentList '/quiet','/features','OptionId.WindowsDesktopDebuggers' ; `
     Remove-Item winsdksetup.exe
 
-ENV PATH="C:\Program Files (x86)\Windows Kits\10\Debuggers\x64;${PATH}"
+# Windows base images set PATH via the registry, not via Dockerfile ENV, so
+# `${PATH}` does NOT expand here — using it would clobber System32 out of PATH
+# and break `powershell`, `where`, etc. List the base-image defaults explicitly.
+ENV PATH="C:\Program Files (x86)\Windows Kits\10\Debuggers\x64;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Users\ContainerAdministrator\AppData\Local\Microsoft\WindowsApps"
 
 WORKDIR /app
 COPY publish/win-x64/ ./


### PR DESCRIPTION
The Dockerfile set PATH via `ENV PATH="...;${PATH}"`, but Windows base images do not declare PATH through Dockerfile ENV — they set it through the registry. Docker therefore did not expand `${PATH}` and the resulting container PATH contained only the Debuggers directory.

That broke the HEALTHCHECK probe (`powershell` not found in PATH), so the container reported `unhealthy` even though the service inside was fully operational. Reproduced locally with v1.0.6: probe output was `'powershell' is not recognized as an internal or external command`.

Fix by listing the base-image default PATH entries explicitly.

Verified end-to-end with a local build:
- HEALTHCHECK transitions starting → healthy in ~6 s (was: unhealthy at 73 s)
- /api/jobs, /api/diagnostics/health, /api/diagnostics/detect-debuggers, /api/diagnostics/analyses all return 200 from inside the container
- TestCrasher dump loaded in 8 s, basic-analysis completed in 50 s, symbols (ntdll, kernel32, coreclr, …) cached from Microsoft Symbol Server
