### PR TITLE
 feat(docker): env-driven binding + persistent symbol-cache default

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -8,7 +8,7 @@
       "type": "http",
       "url": "http://localhost:7997/mcp",
       "headers": {
-        "X-Symbol-Cache": "D:\\Symbols",
+        "X-Symbol-Cache": "C:\\symbols",
         "X-Symbol-Path-Extra": "",
         "X-Symbol-Servers": ""
       }

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,6 @@ ENV Debugger__DefaultSymbolCache=C:\symbols
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 `
   CMD powershell -Command "try { Invoke-WebRequest http://localhost:7997/api/jobs -UseBasicParsing | Out-Null; exit 0 } catch { exit 1 }"
 
-# All configuration is via environment variables (see ENV above) so the same
-# image works locally and in Azure without command/ENTRYPOINT edits.
+# All configuration is via environment variables
+# so, image works locally and in Azure.
 ENTRYPOINT ["DumpAnalysisService.exe"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,21 @@ WORKDIR /app
 COPY publish/win-x64/ ./
 
 EXPOSE 7997
+
+# Bind on all interfaces so the published port is reachable from the host,
+# another machine, or Azure. WebApplication reads ASPNETCORE_URLS natively;
+# Program.cs only falls back to a loopback URL when this is unset.
 ENV ASPNETCORE_URLS=http://+:7997
+
+# Fixed, mount-friendly symbol-cache default. Persistence is provided by the
+# mount, not the app: -v C:\hostsymbols:C:\symbols locally, or an Azure Files
+# share mounted on C:\symbols shared across autoscaled replicas. Override with
+# -e Debugger__DefaultSymbolCache=... or the per-request X-Symbol-Cache header.
+ENV Debugger__DefaultSymbolCache=C:\symbols
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 `
   CMD powershell -Command "try { Invoke-WebRequest http://localhost:7997/api/jobs -UseBasicParsing | Out-Null; exit 0 } catch { exit 1 }"
 
+# All configuration is via environment variables (see ENV above) so the same
+# image works locally and in Azure without command/ENTRYPOINT edits.
 ENTRYPOINT ["DumpAnalysisService.exe"]

--- a/DumpAnalysisService/Program.cs
+++ b/DumpAnalysisService/Program.cs
@@ -96,14 +96,24 @@ public partial class Program
             // Map SignalR hub
             app.MapHub<Hubs.ProgressHub>("/hubs/progress");
 
-            // Start the service
-            var port = args.Length > 0 && int.TryParse(args[0], out var p) ? p : Constants.Network.DefaultPort;
-            app.Urls.Add($"http://localhost:{port}");
+            // Start the service.
+            // Docker/Azure set ASPNETCORE_URLS (e.g. http://+:7997) and WebApplication
+            // binds from it natively. Programmatic app.Urls.Add OVERRIDES ASPNETCORE_URLS,
+            // so only add an explicit loopback URL for local runs where the env var is
+            // absent. To bind elsewhere (different port or interface), set ASPNETCORE_URLS.
+            if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("ASPNETCORE_URLS")))
+                app.Urls.Add($"http://localhost:{Constants.Network.DefaultPort}");
 
-            logger.LogInformation("Dump Analysis Service listening on port {Port}", port);
-            logger.LogInformation("MCP HTTP endpoint available at http://localhost:{Port}/mcp", port);
-            logger.LogInformation("REST API available at http://localhost:{Port}/api", port);
-            logger.LogInformation("SignalR hub available at http://localhost:{Port}/hubs/progress", port);
+            app.Lifetime.ApplicationStarted.Register(() =>
+            {
+                foreach (var boundUrl in app.Urls)
+                {
+                    logger.LogInformation("Dump Analysis Service listening on {Url}", boundUrl);
+                    logger.LogInformation("MCP HTTP endpoint available at {Url}/mcp", boundUrl);
+                    logger.LogInformation("REST API available at {Url}/api", boundUrl);
+                    logger.LogInformation("SignalR hub available at {Url}/hubs/progress", boundUrl);
+                }
+            });
 
             await app.RunAsync();
             return 0;

--- a/README.md
+++ b/README.md
@@ -98,16 +98,28 @@ Pre-built Windows container images are published to GitHub Container Registry on
 docker run -d --name windbg `
   -p 7997:7997 `
   -v C:\dumps:C:\dumps:ro `
-  -v cdb-symbols:C:\symcache `
-  -e Debugger__DefaultSymbolCache=C:\symcache `
+  -v cdb-symbols:C:\symbols `
   ghcr.io/janecekvit/mcp-windbg:latest
 ```
+
+No `-e Debugger__DefaultSymbolCache` is needed — the image already defaults the cache to `C:\symbols`, so you only mount a volume there. To override the location, see [Environment variables](#environment-variables).
 
 Then call the REST API:
 
 ```powershell
 Invoke-RestMethod http://localhost:7997/api/jobs   # empty array []
 ```
+
+### Connecting an MCP client / AI from outside the container
+
+The service binds to all interfaces (`ASPNETCORE_URLS=http://+:7997`, baked into
+the image), so the published port is reachable from the host or another machine.
+Point your MCP client at:
+
+- **Local host:** `http://localhost:7997/mcp`
+- **Remote / Azure:** `http://<public-host-or-ip>:7997/mcp`
+
+REST API and SignalR live under the same host at `/api` and `/hubs/progress`.
 
 ### docker-compose example
 
@@ -119,9 +131,9 @@ services:
       - "7997:7997"
     volumes:
       - C:\dumps:C:\dumps:ro
-      - cdb-symbols:C:\symcache
+      - cdb-symbols:C:\symbols
     environment:
-      Debugger__DefaultSymbolCache: C:\symcache
+      Debugger__DefaultSymbolCache: C:\symbols
       Debugger__DefaultSymbolPathExtra: ""
       Debugger__DefaultSymbolServers: ""
     restart: unless-stopped
@@ -136,7 +148,7 @@ ASP.NET Core maps `Section__Key` env vars onto the `appsettings.json` tree, so t
 
 | Env var | Maps to | Purpose |
 |---|---|---|
-| `Debugger__DefaultSymbolCache` | `Debugger:DefaultSymbolCache` | Local symbol cache directory inside the container (default `%LOCALAPPDATA%\CdbMcpServer\symbols` — override to a mounted volume so symbols persist across container restarts) |
+| `Debugger__DefaultSymbolCache` | `Debugger:DefaultSymbolCache` | Local symbol cache directory inside the container (default in the container image: `C:\symbols` — mount a volume there so symbols persist across restarts; outside Docker the .exe defaults to `%LOCALAPPDATA%\DumpAnalysisService\symbols`) |
 | `Debugger__DefaultSymbolPathExtra` | `Debugger:DefaultSymbolPathExtra` | Semicolon-separated extra local symbol paths (e.g. `C:\my-pdbs;\\server\symbols`) |
 | `Debugger__DefaultSymbolServers` | `Debugger:DefaultSymbolServers` | Semicolon-separated extra symbol servers; Microsoft public symbol server is always included |
 
@@ -150,6 +162,32 @@ Always pin to `:vX.Y.Z` in production / scripted use. `:latest` is convenient lo
 - **First `load_dump` against a new symbol cache takes 10-30 minutes** while Microsoft Symbol Server downloads PDBs. Second run from the cached volume: 30-60 seconds.
 - **Dump file paths must be visible inside the container** — mount the host directory containing dumps (e.g. `-v C:\dumps:C:\dumps:ro`) and pass that *container* path in `DumpPath`, not the host path.
 - Symbol cache is intentionally **not pre-baked** into the image — symbols rotate every Patch Tuesday, so a baked cache would just rot. Mount a named volume (`cdb-symbols`) to make the cache survive container restarts.
+
+### Deploying to Azure
+
+The same image runs in Azure with configuration supplied entirely through app
+settings (which Azure exposes as environment variables) — no rebuild, no
+ENTRYPOINT edits. Pick a **Windows-container-capable** service:
+
+| Service | Fit |
+|---|---|
+| Azure Container Instances (ACI) | Cheapest; good for a single instance or one instance per customer; no load balancer or autoscaling. |
+| App Service for Containers (Windows) | Simplest managed option; built-in scale-out + load balancer (requires a Windows-container-capable plan, e.g. Premium v3). |
+| AKS (Windows node pool) | Full orchestrator: autoscaling, load balancing, health probes across replicas. |
+
+> **Azure Container Apps is NOT an option** — it does not support Windows
+> containers, and `cdb.exe` is Windows-native (no Linux build exists).
+
+**Shared symbol cache across replicas:** for the autoscaled options (App Service,
+AKS), mount an **Azure Files** SMB share on `C:\symbols` in *every* replica.
+Symbols download once and are shared behind the load balancer instead of each
+replica re-downloading them. Azure Files supports concurrent multi-mount access;
+the symsrv cache is read-mostly and uses file locking, so concurrent-write risk
+is low. Set `Debugger__DefaultSymbolCache=C:\symbols` (already the image default)
+and point the mount at it.
+
+Deployment manifests themselves live in a separate repository — this section
+documents only the image contract those manifests rely on.
 
 ## Automatic Debugger Detection
 


### PR DESCRIPTION
## Summary

  - Fixes a bind bug where the v1.0.7 image set `ASPNETCORE_URLS=http://+:7997` but `Program.cs` unconditionally called `app.Urls.Add("http://localhost:...")`, which overrides the env var and made Kestrel bind to loopback only — so port 7997 was unreachable from the host.
  - Makes the image fully env-driven so the *same* image runs locally and in Azure with no command-line/ENTRYPOINT edits: bakes `ASPNETCORE_URLS=http://+:7997` and `Debugger__DefaultSymbolCache=C:\symbols` into the Dockerfile; `Program.cs` only falls back to a loopback URL when
  `ASPNETCORE_URLS` is absent (local dev) and now logs the *actually-bound* URLs via `ApplicationStarted` instead of a hard-coded port.
  - Drops the unused `args[0]` port shortcut — use `ASPNETCORE_URLS` for any local override.
  - README: standardizes the cache path on `C:\symbols` (`.mcp.json`, examples, docker-compose, env-var table), adds a "Connecting from outside the container" note, and adds a "Deploying to Azure" section covering ACI / App Service for Containers (Windows) / AKS (Windows node
  pool) with an Azure Files shared-cache pattern. Calls out explicitly that Azure Container Apps is not an option (no Windows container support; `cdb.exe` is Windows-native).

  ## Why

  The image was advertised as ready to run anywhere but couldn't even serve traffic to the docker host without overriding the entrypoint. Root cause was a single line in `Program.cs` that silently won over the env var. Fixing it in code (not in `docker run` flags) means the same
  image artifact published to `ghcr.io/janecekvit/mcp-windbg` is now usable as-is from local Docker, ACI, App Service, and AKS without per-platform tweaks.

  ## Files

  - `DumpAnalysisService/Program.cs` — skip `app.Urls.Add` when `ASPNETCORE_URLS` is set; move startup logs into `ApplicationStarted.Register` so they reflect bound URLs; drop `args[0]` port shortcut.
  - `Dockerfile` — keep `ENV ASPNETCORE_URLS=http://+:7997`; add `ENV Debugger__DefaultSymbolCache=C:\symbols`; bare `ENTRYPOINT ["DumpAnalysisService.exe"]`.
  - `.mcp.json` — switch sample `X-Symbol-Cache` to `C:\symbols` to match the new default.
  - `README.md` — cache path consistency, external-connectivity note, Azure deployment section.

  ## Test plan

  - [x] `docker build` succeeds against the existing `publish/win-x64/` output (no second build path introduced).
  - [x] `docker run -d -p 7997:7997 -v C:\hostsymbols:C:\symbols mcp-windbg:dev` → container reports healthy.
  - [x] `Invoke-RestMethod http://localhost:7997/api/jobs` from the host returns `[]` (200) — i.e. port is reachable from outside the container, which was the regression.
  - [x] End-to-end MCP load-dump + `basic_analysis` against a real dump via `http://localhost:7997/mcp` resolves symbols against the mounted `C:\symbols` cache (verified with `crash.dmp` — `coreclr.pdb`, `System.Private.CoreLib.ni.pdb`, `ntdll.pdb` all resolved from cache).
  - [x] Local `dotnet run --project DumpAnalysisService` still binds to `http://localhost:7997` when `ASPNETCORE_URLS` is unset.
  - [x] Smoke-test in ACI / App Service (Windows) once the deployment manifests in the sibling repo are updated to point at the new image tag — out of scope for this PR.
